### PR TITLE
tilesParser ignores empty lines from ascii map

### DIFF
--- a/src/lib/tileGenerator.js
+++ b/src/lib/tileGenerator.js
@@ -35,6 +35,7 @@ const asciiTile = {
 
 const parseTiles = asciiMap => asciiMap
   .split('\n')
+  .filter(row => row.length != 0)
   .map(row => row
     .split('')
     .map(ascii => ascii.toUpperCase())
@@ -61,7 +62,6 @@ const findPlayer = (level, asciiMap) => {
 }
 
 export const generateTiles = (level, lesson) => {
-  console.log(lesson)
   if (level || lesson) {
     return {
       tiles: parseTiles(

--- a/src/screens/Lessons.js
+++ b/src/screens/Lessons.js
@@ -71,9 +71,7 @@ export default (props) => {
   return (
     <div className="container">
       <div className="game-container">
-        <div className="game">
-          <Room lesson={lesson} />
-        </div>
+        <Room lesson={lesson} />
         <div className="lesson-container">
           <Lesson
             lesson={lesson}


### PR DESCRIPTION
grid is now correctly 10x8

## Before

![image](https://user-images.githubusercontent.com/132562/97659358-0f268d00-1a2c-11eb-9a45-cd3ab3ea1478.png)


## After

![image](https://user-images.githubusercontent.com/132562/97659332-f9b16300-1a2b-11eb-8b50-811902007834.png)
